### PR TITLE
COMRS-158: Adding configuration to hide birth time from the registration page

### DIFF
--- a/openmrs/apps/registration/app.json
+++ b/openmrs/apps/registration/app.json
@@ -60,7 +60,7 @@
             "showMiddleName": true,
             "showLastName": true,
             "isLastNameMandatory": true,
-            "showBirthTime": true,
+            "showBirthTime": false,
             "showCasteSameAsLastNameCheckbox": false,
             "printOptions": [
                 {


### PR DESCRIPTION
https://jembiprojects.jira.com/browse/COMRS-158

On the registration page, 'birth time' field is available. This field can be configured to be hidden.

The default behavior from Bahmni (i.e.. when the configuration is not available) is to show the field always.
To hide 'birth time' field, follow these steps:

- Go to bahmni-config, the settings are available at bahmni-config/openmrs/apps/registration/app.json.

- Add (...or edit if the line is already there) the following piece of configuration in the 'config' section of the file:
`"showBirthTime": false
`


