### PR TITLE
COM-249 Remove orders fulfilment widget from the dashboard

### DIFF
--- a/openmrs/apps/clinical/dashboard.json
+++ b/openmrs/apps/clinical/dashboard.json
@@ -87,30 +87,6 @@
                     "numberOfVisits":4
                 }
             },
-            "labOrdersDisplayControl":{  
-                "translationKey":"DASHBOARD_TITLE_LAB_ORDERS_DISPLAY_CONTROL_KEY",
-                "type":"ordersControl",
-                "orderType":"Lab Order",
-                "showDetailsButton":true,
-                "displayOrder":9,
-                "dashboardConfig":{  
-                    "conceptNames":[  
-                        "Systolic",
-                        "Diastolic",
-                        "Posture",
-                        "Temperature"
-                    ]
-                },
-                "expandedViewConfig":{  
-                    "conceptNames":[  
-                        "Systolic",
-                        "Diastolic",
-                        "Posture",
-                        "Temperature"
-                    ],
-                    "showDetailsButton":true
-                }
-            },
             "bacteriologyResults":{  
                 "translationKey":"DASHBOARD_TITLE_BACTERIOLOGY_RESULTS_KEY",
                 "type":"bacteriologyResultsControl",

--- a/openmrs/apps/home/extension.json
+++ b/openmrs/apps/home/extension.json
@@ -69,16 +69,6 @@
     "order": 7,
     "requiredPrivilege": "app:admin"
   },
-  "orders": {
-    "id": "bahmni.orders",
-    "extensionPointId": "org.bahmni.home.dashboard",
-    "type": "link",
-    "translationKey": "MODULE_LABEL_ORDERS_KEY",
-    "url": "../orders/#/search",
-    "icon": "icon-bahmni-orders",
-    "order": 10,
-    "requiredPrivilege": "app:orders"
-  },
   "reports": {
     "id": "bahmni.reports",
     "extensionPointId": "org.bahmni.home.dashboard",
@@ -98,26 +88,6 @@
     "icon": "fa fa-calendar",
     "order": 11,
     "requiredPrivilege": "App: appointmentschedulingui.home"
-  },
-  "implementerInterface": {
-    "id": "bahmni.implementer.interface",
-    "extensionPointId": "org.bahmni.home.dashboard",
-    "type": "link",
-    "translationKey": "MODULE_LABEL_IMPLEMENTER_INTERFACE_KEY",
-    "url": "/implementer-interface",
-    "icon": "fa fa-pencil-square-o",
-    "order": 12,
-    "requiredPrivilege": "app:implementer-interface"
-  },
-  "atomfeedConsole": {
-    "id": "bahmni.atomfeed.console",
-    "extensionPointId": "org.bahmni.home.dashboard",
-    "type": "link",
-    "translationKey": "MODULE_LABEL_ATOMFEED_CONSOLE_KEY",
-    "url": "/atomfeed-console",
-    "icon": "fa fa-terminal",
-    "order": 13,
-    "requiredPrivilege": "app:admin"
   },
   "appointmentScheduling": {
     "id": "bahmni.appointment.scheduling",


### PR DESCRIPTION
1. Removed orders fulfilment widget from the clinical dashboard
2. Removed the following tiles from home page, orders, Implementers dashboard, Atom feed console