### PR TITLE
COM-291 Disable enter manual ID in registration

### DIFF
--- a/openmrs/apps/registration/app.json
+++ b/openmrs/apps/registration/app.json
@@ -17,6 +17,7 @@
             "activeVisitUuid"
         ],
         "config" : {
+            "showEnterID": false,
             "patientInformation": {
                 "hidden": {
                     "attributes": [


### PR DESCRIPTION
When entering a manual ID, the sequence gets updated causing issues for future id generations.