### PR TITLE
COM-432 Ordersets - duration not displaying correctly

### DIFF
--- a/openmrs/apps/clinical/medication.json
+++ b/openmrs/apps/clinical/medication.json
@@ -12,7 +12,7 @@
         "defaultInstructions": "As directed",
         "frequencyDefaultDurationUnitsMap": [
           {
-            "minFrequency": "1/7",
+            "minFrequency": "1",
             "maxFrequency": 5,
             "defaultDurationUnit": "Day(s)"
           },


### PR DESCRIPTION
Resolved the bug for duration not displaying correctly.