### PR TITLE
COM-483 Remove frequencyDefaultDurationUnitsMap

### DIFF
--- a/openmrs/apps/clinical/medication.json
+++ b/openmrs/apps/clinical/medication.json
@@ -7,25 +7,10 @@
         "calculateDoseOnlyOnCurrentVisitValues": false
       },
       "inputOptionsConfig": {
-        "defaultDurationUnit": "Jour(s)",
+        "defaultDurationUnit": "Day(s)",
         "hideOrderSet" : false,
         "defaultInstructions": "As directed",
         "frequencyDefaultDurationUnitsMap": [
-          {
-            "minFrequency": "1",
-            "maxFrequency": 5,
-            "defaultDurationUnit": "Jour(s)"
-          },
-          {
-            "minFrequency": "1/30",
-            "maxFrequency": "1/7",
-            "defaultDurationUnit": "Semaine(s)"
-          },
-          {
-            "minFrequency": null,
-            "maxFrequency": "1/30",
-            "defaultDurationUnit": "Mois"
-          }
         ],
         "drugFormDefaults": {
           "Capsule": {


### PR DESCRIPTION
This was removed because it was updating the Duration in the order set members instead of using the pre-determined duration for that member.