### PR TITLE
COM-802 Update indicators not implemented yet to return only 1 record

### DIFF
--- a/openmrs/apps/reports/PECG_REPORT/sql/indicator12_not_available.sql
+++ b/openmrs/apps/reports/PECG_REPORT/sql/indicator12_not_available.sql
@@ -14,5 +14,4 @@ SELECT 'Not Available' AS '-'  ,
             0 AS '25-49 M',
             0 AS '25-49 F',
             0 AS '>=50 M',
-            0 AS '>=50 F'     
-    FROM person;
+            0 AS '>=50 F';

--- a/openmrs/apps/reports/PECG_REPORT/sql/indicator16_not_available.sql
+++ b/openmrs/apps/reports/PECG_REPORT/sql/indicator16_not_available.sql
@@ -14,5 +14,4 @@ SELECT 'Not Available' AS '-'  ,
             0 AS '25-49 M',
             0 AS '25-49 F',
             0 AS '>=50 M',
-            0 AS '>=50 F'     
-    FROM person;
+            0 AS '>=50 F';

--- a/openmrs/apps/reports/PECG_REPORT/sql/indicator1_not_available.sql
+++ b/openmrs/apps/reports/PECG_REPORT/sql/indicator1_not_available.sql
@@ -14,5 +14,4 @@ SELECT 'Not Available' AS '-'  ,
             0 AS '25-49 M',
             0 AS '25-49 F',
             0 AS '>=50 M',
-            0 AS '>=50 F'     
-    FROM person;
+            0 AS '>=50 F';

--- a/openmrs/apps/reports/PECG_REPORT/sql/indicator8_not_available.sql
+++ b/openmrs/apps/reports/PECG_REPORT/sql/indicator8_not_available.sql
@@ -14,5 +14,4 @@ SELECT 'Not Available' AS '-'  ,
             0 AS '25-49 M',
             0 AS '25-49 F',
             0 AS '>=50 M',
-            0 AS '>=50 F'     
-    FROM person;
+            0 AS '>=50 F';

--- a/openmrs/apps/reports/PECG_REPORT/sql/indicator9_not_available.sql
+++ b/openmrs/apps/reports/PECG_REPORT/sql/indicator9_not_available.sql
@@ -14,5 +14,4 @@ SELECT 'Not Available' AS '-'  ,
             0 AS '25-49 M',
             0 AS '25-49 F',
             0 AS '>=50 M',
-            0 AS '>=50 F'     
-    FROM person;
+            0 AS '>=50 F';


### PR DESCRIPTION
There are 5 PECG indicators that are not implemented yet, the dummy placeholder queries were selecting from the table "person" thus returning a row for each patient (i.e. 2000 x 5 records) which negatively affected the report performance. The fix removes the clause 'FROM' to return only 1 record.