### PR TITLE
COM-841 Remove 'patient_id' column from treatment report

### DIFF
--- a/openmrs/apps/reports/RADET/sql/treatment.sql
+++ b/openmrs/apps/reports/RADET/sql/treatment.sql
@@ -1,4 +1,4 @@
-SELECT p.patient_id, getPatientDateOfEnrolmentInProgram(p.patient_id, "HIV_PROGRAM_KEY") AS "Enrollment Date/Date de l'inscription",
+SELECT getPatientDateOfEnrolmentInProgram(p.patient_id, "HIV_PROGRAM_KEY") AS "Enrollment Date/Date de l'inscription",
 	getPatientARTNumber(p.patient_id) as "Patient Unique ID/ART №",
 	getPatientGender(p.patient_id) as "Sex",
 	getPatientBirthdate(p.patient_id) as "Date of birth / (Date de naissance)",


### PR DESCRIPTION
This column was added for debug reason and committed by mistake