### PR TITLE
COM-899 George Town TB report fix

### DIFF
--- a/metadata/reportssql/testing_report_functions.sql
+++ b/metadata/reportssql/testing_report_functions.sql
@@ -1928,7 +1928,8 @@ BEGIN
     WHERE o.voided = 0 AND
         o.concept_id = (SELECT c.concept_id FROM concept c WHERE c.uuid = uuidMTBConfirmation) AND
         o.value_coded = (SELECT c.concept_id FROM concept c WHERE c.uuid = uuidBacteriologicallyConfirmed)
-    ORDER BY o.date_created DESC;
+    ORDER BY o.date_created DESC
+    LIMIT 1;
 
     IF (encounterId IS NULL) THEN
         RETURN NULL;


### PR DESCRIPTION
Report generation was failing. 
Fixed function getDateTBPosDiagnose to limit information retrieved to the last encounter only.