### PR TITLE
COM-956 Include any ART start date (not only within reporting period)

### DIFF
--- a/openmrs/apps/reports/GEORGETOWN_TESTING_REPORT/sql/georgetownTestingReport.sql
+++ b/openmrs/apps/reports/GEORGETOWN_TESTING_REPORT/sql/georgetownTestingReport.sql
@@ -11,7 +11,7 @@ SELECT
     IF(wasHIVTestDoneInANCVisitWithinRepPeriod(p.patient_id, "#startDate#", "#endDate#"), "Yes", patientEligibleForHIVTesting(p.patient_id)) as "eligibleForTesting",
     getHIVTestDate(p.patient_id,"#startDate#", "#endDate#") as "dateOfHivTesting",
     getHIVResult(p.patient_id,"#startDate#", "#endDate#") as "result",
-    DATE(getProgramAttributeValueWithinReportingPeriod(p.patient_id, "#startDate#", "#endDate#", "2dc1aafd-a708-11e6-91e9-0800270d80ce")) as "dateOfArtInitiation",
+    DATE(getProgramAttributeValueWithinReportingPeriod(p.patient_id, "2000-01-01", "2100-12-31", "2dc1aafd-a708-11e6-91e9-0800270d80ce")) as "dateOfArtInitiation",
     getObsCodedValue(p.patient_id, "3447254f-501f-4b07-815c-cd0f6da98158") as "reasonOfNonInitiation",
     IF(wasHIVTestDoneInANCVisitWithinRepPeriod(p.patient_id, "#startDate#", "#endDate#"),"PMTCT [ANC1-only]",getTestingEntryPointWithinRepPeriod(p.patient_id, "#startDate#", "#endDate#")) as "facilityEntryPoint",
     getHIVTestDate(p.patient_id,"#startDate#", "#endDate#") as "dateFinalResultProvidedToPatient"


### PR DESCRIPTION
Removes the condition that restricts ART start date to the reporting period