### PR TITLE
COM-981 Fix patientPrescribedARTDuringPartOfReportingPeriod

### DIFF
--- a/metadata/reportssql/treatment_report_functions.sql
+++ b/metadata/reportssql/treatment_report_functions.sql
@@ -660,7 +660,6 @@ BEGIN
     JOIN drug d ON d.drug_id = do.drug_inventory_id AND d.retired = 0
     WHERE o.patient_id = p_patientId AND o.voided = 0
         AND drugIsARV(d.concept_id)
-        AND o.scheduled_date < p_startDate
         AND calculateTreatmentEndDate(
             o.scheduled_date,
             do.duration,


### PR DESCRIPTION
Removes the condition checking that prescription date is before the reporting period; because as long as the treatment covers even partially the reporting period, the function should return "TRUE" irrespective of when the treatment did start