### PR TITLE
COM-988 Bug Fix on PCR Report

### DIFF
--- a/openmrs/apps/reports/GEORGETOWN_PCR_REPORT/sql/georgetownPcrReport.sql
+++ b/openmrs/apps/reports/GEORGETOWN_PCR_REPORT/sql/georgetownPcrReport.sql
@@ -1,15 +1,15 @@
 SELECT
     CAST(@a:=@a+1 AS CHAR) as "serialNumber",
-    getPatientIdentifier(r.person_b) as "uniquePatientId",
-    getPatientBirthdate(r.person_b) as "dateOfBirth",
-    getPatientAgeInMonthsAtDate(r.person_b, NOW()) as "ageInMonths",
-    getPatientIdentifier(r.person_a) as "motherId",
-    CONCAT(getPatientPreciseLocation(r.person_a),", ",getPatientVillage(r.person_a)) as "mothersAddress",
-    getPatientPhoneNumber(r.person_a) as "mothersContact",
-    getMostRecentTestResultDate(r.person_b,"a5239a85-6f75-4882-9b9b-60168e54b7da","9bb7b360-3790-4e1a-8aca-0d1341663040") as "resultDatePcr",
-    getTestResultWithinReportingPeriod(r.person_b,"2000-01-01","2100-01-01","a5239a85-6f75-4882-9b9b-60168e54b7da","9bb7b360-3790-4e1a-8aca-0d1341663040") as "pcrResult",
-	getProgramAttributeDateValueFromAttributeAndProgramName(r.person_b, "PROGRAM_MANAGEMENT_2_PATIENT_TREATMENT_DATE", "HIV_PROGRAM_KEY") as "artInitiationDate",
-    getObsCodedValue(r.person_b, "3447254f-501f-4b07-815c-cd0f6da98158") as "reasonOfNonInitiation"
+    getPatientIdentifier(r.person_a) as "uniquePatientId",
+    getPatientBirthdate(r.person_a) as "dateOfBirth",
+    getPatientAgeInMonthsAtDate(r.person_a, NOW()) as "ageInMonths",
+    getPatientIdentifier(r.person_b) as "motherId",
+    CONCAT(getPatientPreciseLocation(r.person_b),", ",getPatientVillage(r.person_b)) as "mothersAddress",
+    getPatientPhoneNumber(r.person_b) as "mothersContact",
+    getMostRecentTestResultDate(r.person_a,"a5239a85-6f75-4882-9b9b-60168e54b7da","9bb7b360-3790-4e1a-8aca-0d1341663040") as "resultDatePcr",
+    getTestResultWithinReportingPeriod(r.person_a,"2000-01-01","2100-01-01","a5239a85-6f75-4882-9b9b-60168e54b7da","9bb7b360-3790-4e1a-8aca-0d1341663040") as "pcrResult",
+	getProgramAttributeDateValueFromAttributeAndProgramName(r.person_a, "PROGRAM_MANAGEMENT_2_PATIENT_TREATMENT_DATE", "HIV_PROGRAM_KEY") as "artInitiationDate",
+    getObsCodedValue(r.person_a, "3447254f-501f-4b07-815c-cd0f6da98158") as "reasonOfNonInitiation"
 FROM (SELECT @a:= 0) AS a, relationship r
     JOIN relationship_type rt ON rt.relationship_type_id = r.relationship AND rt.a_is_to_b = "RELATIONSHIP_BIO_MOTHER"
     JOIN patient_identifier pi ON pi.patient_id = r.person_a AND pi.preferred = 1;  

--- a/report-testing-framework/report-testing/src/test/java/org/jembi/bahmni/report_testing/georgetown_reports/GeorgetownPCRReportTests.java
+++ b/report-testing-framework/report-testing/src/test/java/org/jembi/bahmni/report_testing/georgetown_reports/GeorgetownPCRReportTests.java
@@ -55,8 +55,8 @@ public class GeorgetownPCRReportTests extends BaseReportTest {
 
         /* record relationship between mother and child */
         testDataGenerator.registration.addRelationshipToPatient(
-            patientIdMother,
             patientIdChild,
+            patientIdMother,
             RelationshipEnum.RELATIONSHIP_BIO_MOTHER,
             RelationshipEnum.RELATIONSHIP_BIO_CHILD);
 
@@ -163,13 +163,13 @@ public class GeorgetownPCRReportTests extends BaseReportTest {
 
         /* record relationship between mother and child */
         testDataGenerator.registration.addRelationshipToPatient(
-            patientIdMother,
             patientIdChild1,
+            patientIdMother,
             RelationshipEnum.RELATIONSHIP_BIO_MOTHER,
             RelationshipEnum.RELATIONSHIP_BIO_CHILD);
         testDataGenerator.registration.addRelationshipToPatient(
-            patientIdMother,
             patientIdChild2,
+            patientIdMother,
             RelationshipEnum.RELATIONSHIP_BIO_MOTHER,
             RelationshipEnum.RELATIONSHIP_BIO_CHILD);
 


### PR DESCRIPTION
The report should display the child’s date of birth (not the mother’s)

The child and mother id columns are inverted (Patient ID should print the child’s ID, and Mother ID, the mother’s)