### PR TITLE
COM-988 Include only children <= 24 months in the report

### DIFF
--- a/openmrs/apps/reports/GEORGETOWN_PCR_REPORT/sql/georgetownPcrReport.sql
+++ b/openmrs/apps/reports/GEORGETOWN_PCR_REPORT/sql/georgetownPcrReport.sql
@@ -12,4 +12,5 @@ SELECT
     getObsCodedValue(r.person_a, "3447254f-501f-4b07-815c-cd0f6da98158") as "reasonOfNonInitiation"
 FROM (SELECT @a:= 0) AS a, relationship r
     JOIN relationship_type rt ON rt.relationship_type_id = r.relationship AND rt.a_is_to_b = "RELATIONSHIP_BIO_MOTHER"
-    JOIN patient_identifier pi ON pi.patient_id = r.person_a AND pi.preferred = 1;  
+    JOIN patient_identifier pi ON pi.patient_id = r.person_a AND pi.preferred = 1
+WHERE getPatientAgeInMonthsAtDate(r.person_a, NOW()) <= 24;


### PR DESCRIPTION
Includes only children <= 24 months in the report