### PR TITLE
COM-1034 Add docker login to travis script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ before_install:
 - chmod 600 /tmp/deploy_key
 - ssh-add /tmp/deploy_key
 - cd report-testing-framework
+- echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 - sh start_mysql_test_db.sh
 addons:
   ssh_known_hosts:


### PR DESCRIPTION
To avoid build fails caused by the limit on the number of pull requests on anonymous docker account (see: https://www.docker.com/increase-rate-limits?utm_source=docker&utm_medium=web%20referral&utm_campaign=increase%20rate%20limit&utm_budget= )