### PR TITLE
COM-1051 Include patients only offered index testing to index service report

### DIFF
--- a/openmrs/apps/reports/GEORGETOWN_INDEX_SERVICE_REPORT/sql/georgetownIndexServiceReport.sql
+++ b/openmrs/apps/reports/GEORGETOWN_INDEX_SERVICE_REPORT/sql/georgetownIndexServiceReport.sql
@@ -17,7 +17,7 @@ SELECT
     getNumberSiblingsOfIndex(p.patient_id, "#startDate#", "#endDate#") as "Number of Siblings",
     getNumberSexualContactsOfIndex(p.patient_id) as "Number of Sexual Contact"
 FROM patient p, (SELECT @a:= 0) AS a
-WHERE patientIsIndex(p.patient_id) AND
+WHERE
     getPatientHIVFinalTestResult(p.patient_id) LIKE "Positive%"  AND
     getPatientIndexTestingDateOffered(p.patient_id) IS NOT NULL AND
     getPatientIndexTestingDateOffered(p.patient_id) BETWEEN "#startDate#" AND "#endDate#";


### PR DESCRIPTION
Updates the index service line listing report to also include patients that have been offered index testing without accepting it