### PR TITLE
Change the report title from PCR Line_listing report to HEI Follow-up…

### DIFF
--- a/openmrs/apps/reports/reports.json
+++ b/openmrs/apps/reports/reports.json
@@ -1667,7 +1667,7 @@
         }
     },
     "georgetownPcrReport": {
-        "name": "PCR Line Listing Report",
+        "name": "HEI Follow-up Line Listing report",
         "type": "concatenated",
         "config": {
             "macroTemplatePath": "/var/www/bahmni_config/openmrs/apps/reports/GEORGETOWN_PCR_REPORT/template/georgetownPcrReport.xls",


### PR DESCRIPTION
During the workshop to review the reports in the EMR in order to improve the quality of these reports, it was proposed by Georgetown University and validated by all the participants, according to the document shared by , in the name of "EMR REPORT MODIFICATIONS & FUNCTIONALITIES" that the report of "PCR Line_listing report" should be renamed to "HEI Follow-up Line Listing report"