### PR TITLE
COM-1248 An old patient never dispensed should never be included

### DIFF
--- a/openmrs/apps/reports/GEORGETOWN_HIV_PATIENT_ON_TREATMENT_REPORT/sql/georgetownHIVPatientOnTreatmentReport.sql
+++ b/openmrs/apps/reports/GEORGETOWN_HIV_PATIENT_ON_TREATMENT_REPORT/sql/georgetownHIVPatientOnTreatmentReport.sql
@@ -51,6 +51,8 @@ WHERE
         (
             patientHasStartedARVTreatmentBefore(pat.patient_id, "#startDate#")
             AND
+            getLastArvPickupDate(pat.patient_id, "2000-01-01", "2100-01-01") IS NOT NULL
+            AND
             (
                 patientHasBeenDispensedARVDuringFullMonth(pat.patient_id, "#startDate#", "#endDate#")
                 OR

--- a/report-testing-framework/report-testing/src/test/java/org/jembi/bahmni/report_testing/georgetown_reports/GeorgetownHIVPatientOnTreatmentReportTests.java
+++ b/report-testing-framework/report-testing/src/test/java/org/jembi/bahmni/report_testing/georgetown_reports/GeorgetownHIVPatientOnTreatmentReportTests.java
@@ -101,6 +101,24 @@ public class GeorgetownHIVPatientOnTreatmentReportTests extends BaseReportTest {
     }
 
     @Test
+    public void anOldPatient_withHIVTreatmentStartingBeforeReportingPeriod_andNeverBeenDispensedARV_shouldNotBeReported() throws Exception {
+        // Prepare
+        createAPatientEnrolledInHIVWithTreatmentStartingOn(
+            new LocalDate(2022, 10, 01),
+            null,
+            0
+        );
+
+        // Execute
+        List<Map<String,Object>> result = runPatientOnTreatmentReport(
+            new LocalDate(2023, 1, 1),
+            new LocalDate(2023, 1, 31));
+
+        // Assert
+        assertEquals(0, result.size());
+    }
+
+    @Test
     public void aPatientOnUnplannedAid_shouldNotBeReported() throws Exception {
         // Prepare
         int patientId = createAPatientEnrolledInHIVWithTreatmentStartingOn(new LocalDate(2023, 1, 01));


### PR DESCRIPTION
The patient on treatment line listing should never include an old patient that has never been prescribed ARV