### PR TITLE
COM-1245 Fix concatenateARTDrugs to include last hour of the day

### DIFF
--- a/metadata/reportssql/drug_functions.sql
+++ b/metadata/reportssql/drug_functions.sql
@@ -977,7 +977,7 @@ BEGIN
         AND drugIsARV(d.concept_id)
         AND o.order_action <> "DISCONTINUE"
         AND o.date_stopped IS NULL
-        AND o.scheduled_date BETWEEN p_startDate AND p_endDate;
+        AND o.scheduled_date BETWEEN p_startDate AND DATE_ADD(p_endDate + INTERVAL 1 DAY, INTERVAL -1 SECOND);
         
     RETURN result;
 END$$

--- a/report-testing-framework/report-testing/src/test/java/org/jembi/bahmni/report_testing/georgetown_reports/GeorgetownPatientInformationReportTests.java
+++ b/report-testing-framework/report-testing/src/test/java/org/jembi/bahmni/report_testing/georgetown_reports/GeorgetownPatientInformationReportTests.java
@@ -100,7 +100,7 @@ public class GeorgetownPatientInformationReportTests extends BaseReportTest {
                                 patientId,
                                 encounterIdOpdVisit,
                                 DrugNameEnum.ABC_3TC_60_30MG,
-                                new LocalDateTime(2020, 1, 5, 8, 0, 0),
+                                new LocalDateTime(2020, 1, 5, 8, 30, 0),
                                 1,
                                 DurationUnitEnum.MONTH,
                                 true);


### PR DESCRIPTION
When verifying if the drug dispence date time is between 2 date, the second date needs to include the time component (set to 23:59:59) to include the full day range